### PR TITLE
Create constants

### DIFF
--- a/recipes/constants
+++ b/recipes/constants
@@ -1,0 +1,1 @@
+(constants :fetcher github :repo "cdominik/constants-for-Emacs")


### PR DESCRIPTION
### Brief summary of what the package does

Insert physical constants and units into a source code buffer.

When I write small programs to calculate something, I often need
the values of some physical constants and units.  I could of course
always link a big module with all those definitions.  But often I
want the program to run stand-alone, so I prefer to define
variables for these constants directly.  This package provides the
command `constants-insert'.  It prompts for one or more variable
names and inserts definition statements for numerical constants
into source code.  It does this in the appropriate syntax for many
different programming languages.

### Direct link to the package repository

https://github.com/cdominik/constants-for-Emacs

### Your association with the package

Creator and maintainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
